### PR TITLE
Changed the if check to prevent error

### DIFF
--- a/ScClient/Socket.cs
+++ b/ScClient/Socket.cs
@@ -123,7 +123,7 @@ namespace ScClient
         }
         private void websocket_MessageReceived(object sender, MessageReceivedEventArgs e)
         {
-            if (e.Message == "#1")
+            if (e.Message.Contains("1") && !e.Message.Contains("data"))
             {
                 _socket.Send("#2");
             }


### PR DESCRIPTION
Sometimes the first websocket contains #1 and sometimes 1, just check if it contains a 1 and if it not contains any other data. You can probably change it to .contains("1") && contains("#1") if there are no other 1's 😁 