### PR TITLE
Do not attempt to connect if already connected or connecting

### DIFF
--- a/ScClient/Socket.cs
+++ b/ScClient/Socket.cs
@@ -215,6 +215,10 @@ namespace ScClient
 
         public void Connect()
         {
+            if (_socket.State == WebSocketState.Connecting || _socket.State == WebSocketState.Open)
+            {
+                return;
+            }
             _socket.Open();
         }
 

--- a/ScClient/Socket.cs
+++ b/ScClient/Socket.cs
@@ -217,6 +217,7 @@ namespace ScClient
         {
             if (_socket.State == WebSocketState.Connecting || _socket.State == WebSocketState.Open)
             {
+                Console.WriteLine("Socket already connected");
                 return;
             }
             _socket.Open();


### PR DESCRIPTION
Prevents an edge case where the socket is in sleeping for a reconnect, but the client calls connect before the reconnect fires.